### PR TITLE
Add streaming service icons to slot game

### DIFF
--- a/game-core.js
+++ b/game-core.js
@@ -1,15 +1,20 @@
 // --- SYMBOLS & CANVAS SETUP ---
+// Image objects for icons
+let netflixImage = new Image();
+let spotifyImage = new Image();
+let youtubeImage = new Image();
+
 export const SYMBOLS = [
-    { name: "Ruby", color: "#ff225a", service: "Netflix", draw: drawRuby },
-    { name: "Emerald", color: "#22df71", service: "Spotify", draw: drawEmerald },
-    { name: "Sapphire", color: "#229aff", service: "YouTube Premium", draw: drawSapphire },
+    { name: "Netflix", service: "Netflix", draw: drawNetflixIcon, imagePath: "icons/netflix.png", imageRef: netflixImage },
+    { name: "Spotify", service: "Spotify", draw: drawSpotifyIcon, imagePath: "icons/spotify.png", imageRef: spotifyImage },
+    { name: "YouTube", service: "YouTube Premium", draw: drawYouTubeIcon, imagePath: "icons/YouTube.png", imageRef: youtubeImage },
     { name: "Amethyst", color: "#af4ee7", service: null, draw: drawAmethyst },
     { name: "Coin", color: "#ffe45c", service: "Credits", draw: drawCoin }
 ];
 export const SERVICE_MAPPING = {
-    Ruby: "Netflix",
-    Emerald: "Spotify",
-    Sapphire: "YouTube Premium",
+    Netflix: "Netflix",
+    Spotify: "Spotify",
+    YouTube: "YouTube Premium",
     Coin: "Credits",
     Amethyst: null
 };
@@ -128,6 +133,72 @@ export function drawCoin(ctx) {
     ctx.restore();
 }
 
+function drawNetflixIcon(ctx) {
+    if (netflixImage && netflixImage.complete && netflixImage.naturalWidth > 0) {
+        const aspectRatio = netflixImage.naturalWidth / netflixImage.naturalHeight;
+        let w = 64, h = 64;
+        if (aspectRatio > 1) {
+            h = 64 / aspectRatio;
+        } else {
+            w = 64 * aspectRatio;
+        }
+        const xOffset = (64 - w) / 2;
+        const yOffset = (64 - h) / 2;
+        ctx.drawImage(netflixImage, xOffset, yOffset, w, h);
+    } else {
+        ctx.fillStyle = "#555";
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.fillStyle = "white";
+        ctx.font = "12px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText("NFX", 32, 36);
+    }
+}
+
+function drawSpotifyIcon(ctx) {
+    if (spotifyImage && spotifyImage.complete && spotifyImage.naturalWidth > 0) {
+        const aspectRatio = spotifyImage.naturalWidth / spotifyImage.naturalHeight;
+        let w = 64, h = 64;
+        if (aspectRatio > 1) {
+            h = 64 / aspectRatio;
+        } else {
+            w = 64 * aspectRatio;
+        }
+        const xOffset = (64 - w) / 2;
+        const yOffset = (64 - h) / 2;
+        ctx.drawImage(spotifyImage, xOffset, yOffset, w, h);
+    } else {
+        ctx.fillStyle = "#555";
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.fillStyle = "white";
+        ctx.font = "12px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText("SPT", 32, 36);
+    }
+}
+
+function drawYouTubeIcon(ctx) {
+    if (youtubeImage && youtubeImage.complete && youtubeImage.naturalWidth > 0) {
+        const aspectRatio = youtubeImage.naturalWidth / youtubeImage.naturalHeight;
+        let w = 64, h = 64;
+        if (aspectRatio > 1) {
+            h = 64 / aspectRatio;
+        } else {
+            w = 64 * aspectRatio;
+        }
+        const xOffset = (64 - w) / 2;
+        const yOffset = (64 - h) / 2;
+        ctx.drawImage(youtubeImage, xOffset, yOffset, w, h);
+    } else {
+        ctx.fillStyle = "#555";
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.fillStyle = "white";
+        ctx.font = "12px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText("YT", 32, 36);
+    }
+}
+
 // --- REEL AND RENDER LOGIC ---
 export function initReels(randSymbol) {
     reels = [];
@@ -197,4 +268,22 @@ export function spinReel(reel, targetSymbols, cb, randSymbol, renderReels) {
 
 export function randSymbol() {
     return REEL_SYMBOL_DISTRIBUTION[Math.floor(Math.random()*REEL_SYMBOL_DISTRIBUTION.length)];
+}
+
+export function preloadSymbolImages() {
+    const promises = [];
+    SYMBOLS.forEach(symbol => {
+        if (symbol.imagePath && symbol.imageRef) {
+            const promise = new Promise((resolve) => {
+                symbol.imageRef.onload = () => resolve(symbol.imageRef);
+                symbol.imageRef.onerror = () => {
+                    console.error("Failed to load image:", symbol.imagePath);
+                    resolve(null);
+                };
+                symbol.imageRef.src = symbol.imagePath;
+            });
+            promises.push(promise);
+        }
+    });
+    return Promise.all(promises);
 }

--- a/main.js
+++ b/main.js
@@ -1,5 +1,7 @@
 import { setupSlotUI } from './slot-ui.js';
 import { setupPixiBackground } from './pixi-background.js';
 
-setupSlotUI();
-setupPixiBackground();
+(async () => {
+    await setupSlotUI();
+    setupPixiBackground();
+})();

--- a/premium-slot.html
+++ b/premium-slot.html
@@ -63,9 +63,9 @@
       <button id="close-paytable" class="close-btn">&times;</button>
       <h2>Paytable</h2>
       <ul>
-        <li><span class="symbol ruby"></span> Netflix – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
-        <li><span class="symbol emerald"></span> Spotify – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
-        <li><span class="symbol sapphire"></span> YouTube Premium – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
+        <li><span class="symbol netflix"></span> Netflix – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
+        <li><span class="symbol spotify"></span> Spotify – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
+        <li><span class="symbol youtube"></span> YouTube Premium – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
         <li><span class="symbol coin"></span> Coin – 3: <b>1×</b>, 4: <b>3×</b>, 5: <b>10×</b> bet credits</li>
         <li><span class="symbol amethyst"></span> Amethyst – <span class="amethyst-text">No reward</span></li>
       </ul>

--- a/slot-ui.js
+++ b/slot-ui.js
@@ -1,6 +1,6 @@
 import {
     SYMBOLS, REELS, ROWS, reels, winLines, winningSymbols, clearWinLines, clearWinningSymbols,
-    initReels, renderReels, spinReel, randSymbol,
+    initReels, renderReels, spinReel, randSymbol, preloadSymbolImages,
     setAnimating, getAnimating,
     P, DIVIDER_W, REEL_W, SYMBOL_H, CANVAS_W, CANVAS_H
 } from './game-core.js';
@@ -13,7 +13,7 @@ export let state;
 export let balance, lastWin, streak, lastBonus, currentBet;
 export let bonusTimer = null, canBonus = false;
 
-export function setupSlotUI() {
+export async function setupSlotUI() {
     // --- UI elements ---
     const canvas = document.getElementById("slot-canvas");
     const canvasContainer = document.querySelector(".slot-canvas-container");
@@ -64,6 +64,9 @@ export function setupSlotUI() {
         betAmountInputEl.value = currentBet;
         save();
     });
+
+    // Load symbol images before initializing reels
+    await preloadSymbolImages();
 
     // INIT
     initReels(randSymbol);
@@ -178,7 +181,7 @@ export function setupSlotUI() {
         function handleMatch(symbolIdx, count, positions, winHighlightsArr) {
             const symbol = SYMBOLS[symbolIdx];
             if (symbol.name === "Amethyst") return;
-            if (["Ruby", "Emerald", "Sapphire"].includes(symbol.name)) {
+            if (["Netflix", "Spotify", "YouTube"].includes(symbol.name)) {
                 let percent = 0;
                 if (count === 3) percent = 30;
                 else if (count === 4) percent = 80;

--- a/style.css
+++ b/style.css
@@ -401,9 +401,9 @@ body {
   margin-right: 4px;
 }
 
-.ruby    { background: linear-gradient(#ff4881, #b0002f); border: 2px solid #ffd862; }
-.emerald { background: linear-gradient(#2afc89, #159653); border: 2px solid #ffd862; }
-.sapphire{ background: linear-gradient(#37abff, #1c3abf); border: 2px solid #ffd862; border-radius: 50%; }
+.netflix { background: linear-gradient(#ff4881, #b0002f); border: 2px solid #ffd862; }
+.spotify { background: linear-gradient(#2afc89, #159653); border: 2px solid #ffd862; }
+.youtube { background: linear-gradient(#37abff, #1c3abf); border: 2px solid #ffd862; border-radius: 50%; }
 .coin    { background: linear-gradient(#ffe27e, #caa22e); border: 2px solid #ffd862; border-radius: 50%; }
 .amethyst{ background: linear-gradient(#c864ff, #6711a6); border: 2px solid #ffd862; transform: rotate(45deg); }
 .amethyst-text { color: #af4ee7; font-weight: 700; }


### PR DESCRIPTION
## Summary
- add image icons for Netflix, Spotify and YouTube in `game-core.js`
- preload symbol images and draw them with aspect ratio preservation
- update service mapping and winning logic to use new names
- load images asynchronously during UI setup
- update main entry to await async setup
- adjust paytable HTML and CSS for new classes

## Testing
- `node -c game-core.js`
- `node -c slot-ui.js`
- `node -c main.js`


------
https://chatgpt.com/codex/tasks/task_e_6840daef53f08327ade6c912c0177501