### PR TITLE
Add ChatGPT and coin icons

### DIFF
--- a/game-core.js
+++ b/game-core.js
@@ -1,17 +1,24 @@
 // --- SYMBOLS & CANVAS SETUP ---
+// Image objects for icons
+let netflixImage = new Image();
+let spotifyImage = new Image();
+let youtubeImage = new Image();
+let chatgptImage = new Image();
+let coinImage = new Image();
+
 export const SYMBOLS = [
-    { name: "Ruby", color: "#ff225a", service: "Netflix", draw: drawRuby },
-    { name: "Emerald", color: "#22df71", service: "Spotify", draw: drawEmerald },
-    { name: "Sapphire", color: "#229aff", service: "YouTube Premium", draw: drawSapphire },
-    { name: "Amethyst", color: "#af4ee7", service: null, draw: drawAmethyst },
-    { name: "Coin", color: "#ffe45c", service: "Credits", draw: drawCoin }
+    { name: "Netflix", service: "Netflix", draw: drawNetflixIcon, imagePath: "icons/netflix.png", imageRef: netflixImage },
+    { name: "Spotify", service: "Spotify", draw: drawSpotifyIcon, imagePath: "icons/spotify.png", imageRef: spotifyImage },
+    { name: "YouTube", service: "YouTube Premium", draw: drawYouTubeIcon, imagePath: "icons/YouTube.png", imageRef: youtubeImage },
+    { name: "ChatGPT", service: "AI Tool", draw: drawChatGPTIcon, imagePath: "icons/chatgpt.png", imageRef: chatgptImage },
+    { name: "Coin", service: "Credits", draw: drawCoinIcon, imagePath: "icons/coin.png", imageRef: coinImage }
 ];
 export const SERVICE_MAPPING = {
-    Ruby: "Netflix",
-    Emerald: "Spotify",
-    Sapphire: "YouTube Premium",
-    Coin: "Credits",
-    Amethyst: null
+    Netflix: "Netflix",
+    Spotify: "Spotify",
+    YouTube: "YouTube Premium",
+    ChatGPT: "AI Tool",
+    Coin: "Credits"
 };
 export const REEL_SYMBOL_DISTRIBUTION = [0,1,2,3,4,4,4,3,3,2,1,0,4,4,2,3,1,2,0,2];
 export const PAYLINES = [
@@ -39,93 +46,115 @@ export function setAnimating(val) { animating = val; }
 export function getAnimating() { return animating; }
 
 // --- SYMBOL DRAWING ---
-export function drawRuby(ctx) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(32, 4); ctx.lineTo(60,22); ctx.lineTo(52,56); ctx.lineTo(12,56); ctx.lineTo(4,22); ctx.closePath();
-    ctx.fillStyle = "#ff2969";
-    ctx.shadowColor = "#ff8abc"; ctx.shadowBlur = 16;
-    ctx.fill();
-    ctx.restore();
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(32, 8); ctx.lineTo(56,22); ctx.lineTo(48,52); ctx.lineTo(16,52); ctx.lineTo(8,22); ctx.closePath();
-    ctx.fillStyle = "#f44";
-    ctx.globalAlpha = 0.7;
-    ctx.fill();
-    ctx.restore();
+
+function drawNetflixIcon(ctx) {
+    if (netflixImage && netflixImage.complete && netflixImage.naturalWidth > 0) {
+        const aspectRatio = netflixImage.naturalWidth / netflixImage.naturalHeight;
+        let w = 64, h = 64;
+        if (aspectRatio > 1) {
+            h = 64 / aspectRatio;
+        } else {
+            w = 64 * aspectRatio;
+        }
+        const xOffset = (64 - w) / 2;
+        const yOffset = (64 - h) / 2;
+        ctx.drawImage(netflixImage, xOffset, yOffset, w, h);
+    } else {
+        ctx.fillStyle = "#555";
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.fillStyle = "white";
+        ctx.font = "12px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText("NFX", 32, 36);
+    }
 }
-export function drawEmerald(ctx) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(32,4); ctx.lineTo(60,32); ctx.lineTo(32,60); ctx.lineTo(4,32); ctx.closePath();
-    ctx.fillStyle = "#27ff89";
-    ctx.shadowColor = "#9fffcd"; ctx.shadowBlur = 16;
-    ctx.fill();
-    ctx.restore();
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(32,8); ctx.lineTo(56,32); ctx.lineTo(32,56); ctx.lineTo(8,32); ctx.closePath();
-    ctx.fillStyle = "#158f49";
-    ctx.globalAlpha = 0.7;
-    ctx.fill();
-    ctx.restore();
+
+function drawSpotifyIcon(ctx) {
+    if (spotifyImage && spotifyImage.complete && spotifyImage.naturalWidth > 0) {
+        const aspectRatio = spotifyImage.naturalWidth / spotifyImage.naturalHeight;
+        let w = 64, h = 64;
+        if (aspectRatio > 1) {
+            h = 64 / aspectRatio;
+        } else {
+            w = 64 * aspectRatio;
+        }
+        const xOffset = (64 - w) / 2;
+        const yOffset = (64 - h) / 2;
+        ctx.drawImage(spotifyImage, xOffset, yOffset, w, h);
+    } else {
+        ctx.fillStyle = "#555";
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.fillStyle = "white";
+        ctx.font = "12px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText("SPT", 32, 36);
+    }
 }
-export function drawSapphire(ctx) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.arc(32, 32, 28, 0, Math.PI * 2);
-    ctx.fillStyle = "#25a1ef";
-    ctx.shadowColor = "#a0e3ff"; ctx.shadowBlur = 15;
-    ctx.fill();
-    ctx.restore();
-    ctx.save();
-    ctx.beginPath();
-    ctx.arc(32, 32, 19, 0, Math.PI * 2);
-    ctx.fillStyle = "#174ca6";
-    ctx.globalAlpha = 0.45;
-    ctx.fill();
-    ctx.restore();
+
+function drawYouTubeIcon(ctx) {
+    if (youtubeImage && youtubeImage.complete && youtubeImage.naturalWidth > 0) {
+        const aspectRatio = youtubeImage.naturalWidth / youtubeImage.naturalHeight;
+        let w = 64, h = 64;
+        if (aspectRatio > 1) {
+            h = 64 / aspectRatio;
+        } else {
+            w = 64 * aspectRatio;
+        }
+        const xOffset = (64 - w) / 2;
+        const yOffset = (64 - h) / 2;
+        ctx.drawImage(youtubeImage, xOffset, yOffset, w, h);
+    } else {
+        ctx.fillStyle = "#555";
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.fillStyle = "white";
+        ctx.font = "12px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText("YT", 32, 36);
+    }
 }
-export function drawAmethyst(ctx) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(32, 6); ctx.lineTo(52, 32); ctx.lineTo(32, 58); ctx.lineTo(12, 32); ctx.closePath();
-    ctx.fillStyle = "#af4ee7";
-    ctx.shadowColor = "#c497ff"; ctx.shadowBlur = 12;
-    ctx.fill();
-    ctx.restore();
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(32, 14); ctx.lineTo(46, 32); ctx.lineTo(32, 50); ctx.lineTo(18, 32); ctx.closePath();
-    ctx.fillStyle = "#4d1859";
-    ctx.globalAlpha = 0.6;
-    ctx.fill();
-    ctx.restore();
+
+function drawChatGPTIcon(ctx) {
+    if (chatgptImage && chatgptImage.complete && chatgptImage.naturalWidth > 0) {
+        const aspectRatio = chatgptImage.naturalWidth / chatgptImage.naturalHeight;
+        let w = 64, h = 64;
+        if (aspectRatio > 1) {
+            h = 64 / aspectRatio;
+        } else {
+            w = 64 * aspectRatio;
+        }
+        const xOffset = (64 - w) / 2;
+        const yOffset = (64 - h) / 2;
+        ctx.drawImage(chatgptImage, xOffset, yOffset, w, h);
+    } else {
+        ctx.fillStyle = "#777";
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.fillStyle = "white";
+        ctx.font = "12px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText("GPT", 32, 36);
+    }
 }
-export function drawCoin(ctx) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.arc(32,32,28,0,2*Math.PI);
-    ctx.fillStyle = "#ffe45c";
-    ctx.shadowColor = "#fff5c0"; ctx.shadowBlur = 12;
-    ctx.fill();
-    ctx.restore();
-    ctx.save();
-    ctx.beginPath();
-    ctx.arc(32,32,19,0,2*Math.PI);
-    ctx.fillStyle = "#c7ad23";
-    ctx.globalAlpha = 0.75;
-    ctx.fill();
-    ctx.restore();
-    ctx.save();
-    ctx.beginPath();
-    ctx.arc(41,25,7,Math.PI*0.5,Math.PI*1.5);
-    ctx.strokeStyle = "#fff";
-    ctx.globalAlpha = 0.16;
-    ctx.lineWidth = 3.5;
-    ctx.stroke();
-    ctx.restore();
+
+function drawCoinIcon(ctx) {
+    if (coinImage && coinImage.complete && coinImage.naturalWidth > 0) {
+        const aspectRatio = coinImage.naturalWidth / coinImage.naturalHeight;
+        let w = 64, h = 64;
+        if (aspectRatio > 1) {
+            h = 64 / aspectRatio;
+        } else {
+            w = 64 * aspectRatio;
+        }
+        const xOffset = (64 - w) / 2;
+        const yOffset = (64 - h) / 2;
+        ctx.drawImage(coinImage, xOffset, yOffset, w, h);
+    } else {
+        ctx.fillStyle = "#777";
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.fillStyle = "white";
+        ctx.font = "12px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText("CN", 32, 36);
+    }
 }
 
 // --- REEL AND RENDER LOGIC ---
@@ -197,4 +226,22 @@ export function spinReel(reel, targetSymbols, cb, randSymbol, renderReels) {
 
 export function randSymbol() {
     return REEL_SYMBOL_DISTRIBUTION[Math.floor(Math.random()*REEL_SYMBOL_DISTRIBUTION.length)];
+}
+
+export function preloadSymbolImages() {
+    const promises = [];
+    SYMBOLS.forEach(symbol => {
+        if (symbol.imagePath && symbol.imageRef) {
+            const promise = new Promise((resolve) => {
+                symbol.imageRef.onload = () => resolve(symbol.imageRef);
+                symbol.imageRef.onerror = () => {
+                    console.error("Failed to load image:", symbol.imagePath);
+                    resolve(null);
+                };
+                symbol.imageRef.src = symbol.imagePath;
+            });
+            promises.push(promise);
+        }
+    });
+    return Promise.all(promises);
 }

--- a/main.js
+++ b/main.js
@@ -1,5 +1,7 @@
 import { setupSlotUI } from './slot-ui.js';
 import { setupPixiBackground } from './pixi-background.js';
 
-setupSlotUI();
-setupPixiBackground();
+(async () => {
+    await setupSlotUI();
+    setupPixiBackground();
+})();

--- a/premium-slot.html
+++ b/premium-slot.html
@@ -63,11 +63,11 @@
       <button id="close-paytable" class="close-btn">&times;</button>
       <h2>Paytable</h2>
       <ul>
-        <li><span class="symbol ruby"></span> Netflix – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
-        <li><span class="symbol emerald"></span> Spotify – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
-        <li><span class="symbol sapphire"></span> YouTube Premium – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
+        <li><span class="symbol netflix"></span> Netflix – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
+        <li><span class="symbol spotify"></span> Spotify – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
+        <li><span class="symbol youtube"></span> YouTube Premium – 3: <b>30%</b>, 4: <b>80%</b>, 5: <b>100%</b> discount</li>
         <li><span class="symbol coin"></span> Coin – 3: <b>1×</b>, 4: <b>3×</b>, 5: <b>10×</b> bet credits</li>
-        <li><span class="symbol amethyst"></span> Amethyst – <span class="amethyst-text">No reward</span></li>
+        <li><span class="symbol chatgpt"></span> ChatGPT – <span class="chatgpt-text">No reward</span></li>
       </ul>
     </div>
   </div>

--- a/slot-ui.js
+++ b/slot-ui.js
@@ -1,6 +1,6 @@
 import {
     SYMBOLS, REELS, ROWS, reels, winLines, winningSymbols, clearWinLines, clearWinningSymbols,
-    initReels, renderReels, spinReel, randSymbol,
+    initReels, renderReels, spinReel, randSymbol, preloadSymbolImages,
     setAnimating, getAnimating,
     P, DIVIDER_W, REEL_W, SYMBOL_H, CANVAS_W, CANVAS_H
 } from './game-core.js';
@@ -13,7 +13,7 @@ export let state;
 export let balance, lastWin, streak, lastBonus, currentBet;
 export let bonusTimer = null, canBonus = false;
 
-export function setupSlotUI() {
+export async function setupSlotUI() {
     // --- UI elements ---
     const canvas = document.getElementById("slot-canvas");
     const canvasContainer = document.querySelector(".slot-canvas-container");
@@ -64,6 +64,9 @@ export function setupSlotUI() {
         betAmountInputEl.value = currentBet;
         save();
     });
+
+    // Load symbol images before initializing reels
+    await preloadSymbolImages();
 
     // INIT
     initReels(randSymbol);
@@ -177,8 +180,8 @@ export function setupSlotUI() {
         }
         function handleMatch(symbolIdx, count, positions, winHighlightsArr) {
             const symbol = SYMBOLS[symbolIdx];
-            if (symbol.name === "Amethyst") return;
-            if (["Ruby", "Emerald", "Sapphire"].includes(symbol.name)) {
+            if (symbol.name === "ChatGPT") return;
+            if (["Netflix", "Spotify", "YouTube"].includes(symbol.name)) {
                 let percent = 0;
                 if (count === 3) percent = 30;
                 else if (count === 4) percent = 80;

--- a/style.css
+++ b/style.css
@@ -401,12 +401,12 @@ body {
   margin-right: 4px;
 }
 
-.ruby    { background: linear-gradient(#ff4881, #b0002f); border: 2px solid #ffd862; }
-.emerald { background: linear-gradient(#2afc89, #159653); border: 2px solid #ffd862; }
-.sapphire{ background: linear-gradient(#37abff, #1c3abf); border: 2px solid #ffd862; border-radius: 50%; }
+.netflix { background: linear-gradient(#ff4881, #b0002f); border: 2px solid #ffd862; }
+.spotify { background: linear-gradient(#2afc89, #159653); border: 2px solid #ffd862; }
+.youtube { background: linear-gradient(#37abff, #1c3abf); border: 2px solid #ffd862; border-radius: 50%; }
 .coin    { background: linear-gradient(#ffe27e, #caa22e); border: 2px solid #ffd862; border-radius: 50%; }
-.amethyst{ background: linear-gradient(#c864ff, #6711a6); border: 2px solid #ffd862; transform: rotate(45deg); }
-.amethyst-text { color: #af4ee7; font-weight: 700; }
+.chatgpt{ background: linear-gradient(#c864ff, #6711a6); border: 2px solid #ffd862; transform: rotate(45deg); }
+.chatgpt-text { color: #af4ee7; font-weight: 700; }
 
 #spin-history-container {
   width: 260px;


### PR DESCRIPTION
## Summary
- preload ChatGPT and coin images for use on the reels
- draw icons for ChatGPT and coin with aspect ratio preservation
- switch Amethyst symbol to ChatGPT and use coin image
- update paytable and CSS classes
- stop counting ChatGPT as a win in the UI logic

## Testing
- `node -c game-core.js`
- `node -c slot-ui.js`
- `node -c main.js`


------
https://chatgpt.com/codex/tasks/task_e_6840daef53f08327ade6c912c0177501